### PR TITLE
Implemented retransmission, fixed nondeterministic behavior

### DIFF
--- a/3700recv
+++ b/3700recv
@@ -6,7 +6,7 @@ import datetime
 import json
 
 MSG_SIZE = 1500
-TIMEOUT = 30
+TIMEOUT = 3
 # Map of received packets, used to handle duplicates and reorder packets
 PACKETS = {}
 
@@ -44,42 +44,42 @@ def main():
 
     # Now listen for packets
     while True:
-        result = sock.recvfrom(MSG_SIZE)
+        try:
+            result = sock.recvfrom(MSG_SIZE)
+            # If nothing is ready, we hit the timeout
+            if result:
+                (data, addr) = result
+                data = data.decode('ascii')
 
-        # If nothing is ready, we hit the timeout
-        if result:
-            (data, addr) = result
-            data = data.decode('ascii')
+                try:
+                    decoded = json.loads(data)
 
-            try:
-                decoded = json.loads(data)
+                    # If the EOF flag is set, exit
+                    if decoded['eof']:
+                        log("[completed]")
+                        sys.exit(0)
 
-                # If the EOF flag is set, exit
-                if decoded['eof']:
-                    log("[completed]")
-                    sys.exit(0)
+                    # If there is data, we accept it and print it out
+                    if decoded['data']:
+                        # Packet received is in expected order
+                        if decoded['sequence'] == expected_ack:
+                            log(f"[recv data] {decoded['sequence']} ({len(decoded['data'])}) ACCEPTED (in-order)")
+                            sys.stdout.write(decoded['data'])
+                            send_ack(decoded, sock, addr)
+                            expected_ack += len(decoded['data'])
+                            # Print out all packets in order
+                            while expected_ack in PACKETS:
+                                sys.stdout.write(PACKETS[expected_ack])
+                                expected_ack += len(PACKETS[expected_ack])
+                        else:
+                            send_ack(decoded, sock, addr)
 
-                # If there is data, we accept it and print it out
-                if decoded['data']:
-                    # Packet received is in expected order
-                    if decoded['sequence'] == expected_ack:
-                        log(f"[recv data] {decoded['sequence']} ({len(decoded['data'])}) ACCEPTED (in-order)")
-                        sys.stdout.write(decoded['data'])
-                        send_ack(decoded, sock, addr)
-                        expected_ack += len(decoded['data'])
-                        # Print out all packets in order
-                        while expected_ack in PACKETS:
-                            sys.stdout.write(PACKETS[expected_ack])
-                            expected_ack += len(PACKETS[expected_ack])
-                    else:
-                        send_ack(decoded, sock, addr)
+                except (ValueError, KeyError, TypeError) as exc:
+                    log("[recv corrupt packet]")
+                    raise exc
 
-            except (ValueError, KeyError, TypeError) as exc:
-                log("[recv corrupt packet]")
-                raise exc
-        else:
+        except socket.timeout:
             log("[error] timeout")
-            sys.exit(-1)
 
 
 if __name__ == '__main__':

--- a/3700send
+++ b/3700send
@@ -12,88 +12,109 @@ TIMEOUT = 2
 SEQN = 0
 SEQUENCE_TO_MESSAGE = {}
 
+
 def log(string):
-  sys.stderr.write(datetime.datetime.now().strftime("%H:%M:%S.%f") + " " + string + "\n")
-  sys.stderr.flush()
+    sys.stderr.write(datetime.datetime.now().strftime("%H:%M:%S.%f") + " " + string + "\n")
+    sys.stderr.flush()
+
+
+def send(packet, sock, dest):
+    if sock.sendto(json.dumps(packet).encode('ascii'), dest) < len(packet):
+        log("[error] unable to fully send packet")
+    else:
+        log("[send data] " + str(packet['sequence']) + " (" + str(len(packet["data"])) + ")")
+
 
 def send_next_packet(seqn, sock, dest):
-  msg = {"sequence": seqn, "data": "", "ack": False, "eof": False}
-  overhead = len(json.dumps(msg))
-  msg["data"] = sys.stdin.read(DATA_SIZE - overhead)
+    msg = {"sequence": seqn, "data": "", "ack": False, "eof": False}
+    overhead = len(json.dumps(msg))
+    msg["data"] = sys.stdin.read(DATA_SIZE - overhead)
 
-  # Map sequence number to message and store
-  SEQUENCE_TO_MESSAGE[seqn] = msg
+    # Map sequence number to message and store
+    SEQUENCE_TO_MESSAGE[seqn] = msg
 
-  if len(msg["data"]) > 0:
-    assert (len(msg) <= DATA_SIZE), f"ERROR: Datagram is longer ({len(msg)}) than {DATA_SIZE} bytes!!!"
+    if len(msg["data"]) > 0:
+        assert (len(msg) <= DATA_SIZE), f"ERROR: Datagram is longer ({len(msg)}) than {DATA_SIZE} bytes!!!"
+        send(msg, sock, dest)
+        return seqn + len(msg["data"])
+    return seqn
 
-    if sock.sendto(json.dumps(msg).encode('ascii'), dest) < len(msg):
-      log("[error] unable to fully send packet")
-    else:
-      log("[send data] " + str(seqn) + " (" + str(len(msg["data"])) + ")")
-    return seqn + len(msg["data"])
-  return seqn
+
+def retransmit_packets(sock, dest):
+    """
+    Retransmit packets for which no ACK was received
+    :param sock: socket to send over
+    :param dest: destination address of socket
+    :return:
+    """
+    for seq in SEQUENCE_TO_MESSAGE.keys():
+        log("[retransmit packet] " + str(seq))
+        send(SEQUENCE_TO_MESSAGE[seq], sock, dest)
+
 
 def main():
-  # Bind to localhost and an ephemeral port
-  ip_port = sys.argv[1]
-  udp_ip = ip_port[0:ip_port.find(":")]
-  udp_port = int(ip_port[ip_port.find(":")+1:])
-  dest = (udp_ip, udp_port)
+    # Bind to localhost and an ephemeral port
+    ip_port = sys.argv[1]
+    udp_ip = ip_port[0:ip_port.find(":")]
+    udp_port = int(ip_port[ip_port.find(":") + 1:])
+    dest = (udp_ip, udp_port)
 
-  # Set up the socket
-  sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-  sock.settimeout(TIMEOUT)
+    # Set up the socket
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.settimeout(TIMEOUT)
 
-  # Send first packet
-  SEQN = send_next_packet(0, sock, dest)
+    # Send first packet
+    SEQN = send_next_packet(0, sock, dest)
 
-  # Now read in data, send packets
-  while True:
-    log("ABOUT TO SLEEP")
-
-    try:
-      result = sock.recvfrom(MSG_SIZE)
-      if result:
-        (data, _addr) = result
-        data = data.decode('ascii')
+    # Now read in data, send packets
+    while True:
+        log("ABOUT TO SLEEP")
 
         try:
-          decoded = json.loads(data)
+            result = sock.recvfrom(MSG_SIZE)
+            if result:
+                (data, _addr) = result
+                data = data.decode('ascii')
 
-          earliest_sequence_not_acked = min(SEQUENCE_TO_MESSAGE)
+                try:
+                    decoded = json.loads(data)
 
-          # If there is an ack, send next packet
-          if decoded['ack'] ==  earliest_sequence_not_acked + len(SEQUENCE_TO_MESSAGE[earliest_sequence_not_acked]["data"]):
+                    earliest_sequence_not_acked = min(SEQUENCE_TO_MESSAGE.keys())
 
-            log(f"[recv ack] {SEQN}")
+                    # If there is an ack, send next packet
+                    if decoded['ack'] == earliest_sequence_not_acked + len(
+                            SEQUENCE_TO_MESSAGE[earliest_sequence_not_acked]["data"]):
 
-            del SEQUENCE_TO_MESSAGE[min(SEQUENCE_TO_MESSAGE.keys())]
+                        log(f"[recv ack] {SEQN}")
 
-            # Try to send next packet; break if no more data
-            new_seq = send_next_packet(SEQN, sock, dest)
-            if new_seq == SEQN:
-              break
-            SEQN = new_seq
-        except (ValueError, KeyError, TypeError) as e:
-          log(f"[recv corrupt packet] {str(e)}")
+                        del SEQUENCE_TO_MESSAGE[min(SEQUENCE_TO_MESSAGE.keys())]
 
-      log(f"(seqn {SEQN})")
+                        # Try to send next packet; break if no more data
+                        new_seq = send_next_packet(SEQN, sock, dest)
+                        if new_seq == SEQN:
+                            break
+                        SEQN = new_seq
+                except (ValueError, KeyError, TypeError) as e:
+                    log(f"[recv corrupt packet] {str(e)}")
 
-    except socket.timeout as e:
-      log(f"[error] did not recieve ack for {SEQN}")
+            log(f"(seqn {SEQN})")
 
-      earliest_sequence_not_acked = min(SEQUENCE_TO_MESSAGE)
+        except socket.timeout:
+            log(f"[error] did not receive ack for {SEQN}")
+            # earliest_sequence_not_acked = min(SEQUENCE_TO_MESSAGE)
+            #
+            # msg = json.dumps({"sequence": earliest_sequence_not_acked,
+            #                   "data": SEQUENCE_TO_MESSAGE[earliest_sequence_not_acked],
+            #                   "eof": False})
+            #
+            # sock.sendto(msg.encode('ascii'), dest)
+            retransmit_packets(sock, dest)
 
-      msg = json.dumps({"sequence": earliest_sequence_not_acked, 
-        "data": SEQUENCE_TO_MESSAGE[earliest_sequence_not_acked],
-        "eof": False})
+    for x in range(1, 5):
+        log(f"sending eof")
+        sock.sendto(json.dumps({"eof": True}).encode('ascii'), dest)
+    sys.exit(0)
 
-      sock.sendto(msg.encode('ascii'), dest)
-      main()
-
-  sock.sendto(json.dumps({"eof": True, "data": "", "sequence": seqn, "ack": False}).encode('ascii'), dest)
-  sys.exit(0)
 
 if __name__ == '__main__':
-  main()
+    main()


### PR DESCRIPTION
Worse performance but tests aren't nondeterministic anymore. Sender retransmits whenever there are unack'ed packets on sender side.

```
Basic tests (correctness)
  Small 1 Mb/s, 10 ms latency                               [PASS]
  Small 0.1 Mb/s 10 ms latency                              [PASS]
  Small 0.1 Mb/s 50 ms latency                              [PASS]
  Medium 1 Mb/s, 10 ms latency                              [PASS]
  Medium 0.1 Mb/s 10 ms latency                             [PASS]
  Medium 0.1 Mb/s 50 ms latency                             [PASS]
  Large 1 Mb/s, 10 ms latency                               [PASS]
  Large 0.5 Mb/s 10 ms latency                              [PASS]
  Large 0.1 Mb/s 500 ms latency                             [FAIL]

Advanced tests (correctness)
  Small 1Mb/s, 10 ms, 99% duplicate                         [PASS]
  Medium 1Mb/s, 10 ms, 50% reorder 10% drop                 [PASS]
  Medium 1Mb/s, 10 ms, 50% drop                             [FAIL]
  Medium 1Mb/s, 10 ms, 50% delay 25% duplicate              [PASS]
  Medium 5Mb/s, 10 ms, 5% delay 5% duplicate 5% drop        [PASS]
  Large 1Mb/s, 10 ms, 10% delay 10% duplicate               [PASS]
  Large 10Mb/s, 10 ms, 1% drop 1% duplicate 1% drop         [PASS]

Performance tests
  Large 5Mb/s, 10 ms, 10% drop                              [FAIL]
  Large 10Mb/s, 50 ms, 10% drop                             [FAIL]
  Large 10Mb/s, 25 ms, 10% drop 10% duplicate 20% delay     [DATA OK]
    29.895 sec elapsed, 138KB sent
  Huge 5Mb/s, 10 ms                                         [DATA OK]
    15.940 sec elapsed, 1MB sent
```